### PR TITLE
Implement browser/Node crypto wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
 # WebCryptoWrapper
-WebCryptoのラッパー。crypto-js互換
+
+crypto-js 互換の入出力を得られる簡単なラッパーです。ブラウザでは Web Crypto API、Node.js では `crypto.webcrypto.subtle` を利用します。IV を暗号文の先頭に連結するため、CryptoJS と同様に文字列だけで復号できます。
+
+## 使い方
+
+```javascript
+// Node.js
+const CryptoWeb = require('./index');
+
+// Browser (after loading index.js via <script>):
+// const CryptoWeb = window.CryptoWeb;
+
+(async () => {
+  // PBKDF2
+  const key = await CryptoWeb.PBKDF2('password', 'salt', { keySize: 8, iterations: 1000 });
+
+  // AES 暗号化（IVは自動生成）
+  const enc = await CryptoWeb.AES.encrypt('hello', key);
+  console.log(enc.toString());
+
+  // AES 復号
+  const dec = await CryptoWeb.AES.decrypt(enc.toString(), key);
+  console.log(dec.toString());
+
+  // SHA-256
+  const hash = await CryptoWeb.SHA256('message');
+  console.log(hash.toString());
+})();
+```

--- a/index.js
+++ b/index.js
@@ -1,0 +1,140 @@
+(function(root, factory){
+  if(typeof module === 'object' && module.exports){
+    module.exports = factory();
+  }else{
+    root.CryptoWeb = factory();
+  }
+}(typeof self !== 'undefined' ? self : this, function(){
+  const globalObj = typeof self !== 'undefined' ? self : this;
+  let nodeCrypto;
+  try{ nodeCrypto = typeof require === 'function' ? require('node:crypto') : undefined; }
+  catch(e){ try{ nodeCrypto = require('crypto'); }catch(err){ nodeCrypto = undefined; }}
+  const webcrypto = (globalObj.crypto && globalObj.crypto.subtle) ? globalObj.crypto
+                     : (nodeCrypto && nodeCrypto.webcrypto);
+  if(!webcrypto || !webcrypto.subtle){
+    throw new Error('WebCrypto not available');
+  }
+  const subtle = webcrypto.subtle;
+
+  function getRandomBytes(len){
+    if(webcrypto.getRandomValues){
+      return webcrypto.getRandomValues(new Uint8Array(len));
+    }
+    if(nodeCrypto && nodeCrypto.randomBytes){
+      return new Uint8Array(nodeCrypto.randomBytes(len));
+    }
+    throw new Error('No secure random generator');
+  }
+
+  /* enc helpers ---------------------------------------------------------- */
+  const enc = {
+    Utf8: {
+      parse: (str) => new TextEncoder().encode(str),
+      stringify: (bytes) => new TextDecoder().decode(bytes)
+    },
+    Hex: {
+      parse: (hex) => Uint8Array.from(hex.match(/.{2}/g).map(b => parseInt(b, 16))),
+      stringify: (bytes) => Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join('')
+    },
+    Base64: {
+      parse: (b64) => {
+        if(typeof atob === 'function'){
+          return Uint8Array.from(atob(b64), c => c.charCodeAt(0));
+        }
+        return new Uint8Array(Buffer.from(b64, 'base64'));
+      },
+      stringify: (bytes) => {
+        if(typeof btoa === 'function'){
+          return btoa(String.fromCharCode(...bytes));
+        }
+        return Buffer.from(bytes).toString('base64');
+      }
+    }
+  };
+
+  /* PBKDF2 --------------------------------------------------------------- */
+  async function PBKDF2(password, salt, cfg={}){
+    const { iterations = 1000, keySize = 256/32, hash = 'SHA-256' } = cfg;
+    const passBytes = typeof password === 'string' ? enc.Utf8.parse(password) : password;
+    const saltBytes = typeof salt === 'string' ? enc.Utf8.parse(salt) : salt;
+    const baseKey = await subtle.importKey('raw', passBytes, 'PBKDF2', false, ['deriveBits']);
+    const bits = await subtle.deriveBits({name:'PBKDF2', salt: saltBytes, iterations, hash}, baseKey, keySize * 32);
+    const bytes = new Uint8Array(bits);
+    return {
+      words: bytes,
+      sigBytes: bytes.length,
+      toString(encoder = enc.Hex){ return encoder.stringify(bytes); }
+    };
+  }
+
+  /* AES ------------------------------------------------------------------ */
+  const AES = {
+    encrypt: async function(plaintext, key, cfg={}){
+      const ptBytes = typeof plaintext === 'string' ? enc.Utf8.parse(plaintext) : plaintext;
+      let keyBytes;
+      if(typeof key === 'string') keyBytes = enc.Hex.parse(key);
+      else if(key && key.words) keyBytes = key.words;
+      else keyBytes = key;
+      if(![16,24,32].includes(keyBytes.length)) throw new Error('Key length must be 128/192/256 bits');
+      const cryptoKey = await subtle.importKey('raw', keyBytes, {name:'AES-CBC', length:keyBytes.length*8}, false, ['encrypt']);
+      let ivBytes;
+      if(cfg.iv) ivBytes = typeof cfg.iv === 'string' ? enc.Hex.parse(cfg.iv) : cfg.iv;
+      else ivBytes = getRandomBytes(16);
+      const cipherBuf = await subtle.encrypt({name:'AES-CBC', iv: ivBytes}, cryptoKey, ptBytes);
+      const cipherBytes = new Uint8Array(cipherBuf);
+      const combined = new Uint8Array(ivBytes.length + cipherBytes.length);
+      combined.set(ivBytes);
+      combined.set(cipherBytes, ivBytes.length);
+      return {
+        iv: ivBytes,
+        ciphertext: cipherBytes,
+        toString(encoder = enc.Base64){ return encoder.stringify(combined); }
+      };
+    },
+
+    decrypt: async function(ciphertext, key, cfg={}){
+      let ctBytes, ivBytes;
+      if(typeof ciphertext === 'string'){
+        const all = enc.Base64.parse(ciphertext);
+        if(all.length < 17) throw new Error('ciphertext too short');
+        ivBytes = all.slice(0,16);
+        ctBytes = all.slice(16);
+      }else if(ciphertext && ciphertext.ciphertext){
+        ivBytes = ciphertext.iv;
+        ctBytes = ciphertext.ciphertext;
+      }else if(ciphertext && ciphertext.length){
+        ctBytes = ciphertext;
+      }else{
+        throw new Error('invalid ciphertext');
+      }
+      if(cfg.iv) ivBytes = typeof cfg.iv === 'string' ? enc.Hex.parse(cfg.iv) : cfg.iv;
+      if(!ivBytes) throw new Error('IV required');
+      let keyBytes;
+      if(typeof key === 'string') keyBytes = enc.Hex.parse(key);
+      else if(key && key.words) keyBytes = key.words;
+      else keyBytes = key;
+      const cryptoKey = await subtle.importKey('raw', keyBytes, {name:'AES-CBC', length:keyBytes.length*8}, false, ['decrypt']);
+      const plainBuf = await subtle.decrypt({name:'AES-CBC', iv: ivBytes}, cryptoKey, ctBytes);
+      const plainBytes = new Uint8Array(plainBuf);
+      return {
+        words: plainBytes,
+        sigBytes: plainBytes.length,
+        toString(encoder = enc.Utf8){ return encoder.stringify(plainBytes); }
+      };
+    }
+  };
+
+  /* SHA-256 -------------------------------------------------------------- */
+  async function SHA256(data){
+    const bytes = typeof data === 'string' ? enc.Utf8.parse(data) : data;
+    const digest = await subtle.digest('SHA-256', bytes);
+    const res = new Uint8Array(digest);
+    return {
+      words: res,
+      sigBytes: res.length,
+      toString(encoder = enc.Hex){ return encoder.stringify(res); }
+    };
+  }
+
+  return { enc, PBKDF2, AES, SHA256 };
+}));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,22 @@
+{
+  "name": "webcryptowrapper",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "webcryptowrapper",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "crypto-js": "^4.2.0"
+      }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "webcryptowrapper",
+  "version": "1.0.0",
+  "description": "WebCryptoのラッパー。crypto-js互換",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "crypto-js": "^4.2.0"
+  }
+}

--- a/test.js
+++ b/test.js
@@ -1,0 +1,30 @@
+const CryptoJS = require('crypto-js');
+const CryptoWeb = require('./index');
+
+(async () => {
+  // Test sha256
+  const msg = 'Hello World';
+  const hashW = await CryptoWeb.SHA256(msg);
+  console.log('sha256 wrapper:', hashW.toString());
+  console.log('sha256 cryptojs:', CryptoJS.SHA256(msg).toString());
+
+  // Test pbkdf2
+  const keySize = 8; // 8 words = 256 bits
+  const iter = 1000;
+  const keyWrapper = await CryptoWeb.PBKDF2('password', 'salt', { keySize, iterations: iter });
+  const keyCryptoJS = CryptoJS.PBKDF2('password', 'salt', {
+    keySize,
+    iterations: iter,
+    hasher: CryptoJS.algo.SHA256
+  }).toString();
+  console.log('pbkdf2 wrapper:', keyWrapper.toString());
+  console.log('pbkdf2 cryptojs:', keyCryptoJS);
+
+  // AES
+  const keyHex = keyWrapper.toString();
+  const plaintext = 'Secret Message';
+  const enc = await CryptoWeb.AES.encrypt(plaintext, keyHex);
+  console.log('aes encrypt wrapper:', enc.toString());
+  const dec = await CryptoWeb.AES.decrypt(enc.toString(), keyHex);
+  console.log('aes decrypt wrapper:', dec.toString());
+})();


### PR DESCRIPTION
## Summary
- provide a single CryptoWeb object exposing PBKDF2, AES and SHA‑256 helpers
- embed IV in the encrypted output so decrypt works with just the string
- update README example
- adjust the test script for the new API

## Testing
- `npm install`
- `node test.js`


------
https://chatgpt.com/codex/tasks/task_e_6879e1ba97bc8320a19262601d6958bd