### PR TITLE
Improve testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Run test.js on push
+name: Run tests
 
 on:
   push:
@@ -13,4 +13,4 @@ jobs:
         with:
           node-version: '18'
       - run: npm install
-      - run: node test.js
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "WebCryptoのラッパー。crypto-js互換",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node test.js"
   },
   "keywords": [],
   "author": "",

--- a/test.js
+++ b/test.js
@@ -1,30 +1,52 @@
+const assert = require('assert');
 const CryptoJS = require('crypto-js');
 const CryptoWeb = require('./index');
 
 (async () => {
-  // Test sha256
-  const msg = 'Hello World';
-  const hashW = await CryptoWeb.SHA256(msg);
-  console.log('sha256 wrapper:', hashW.toString());
-  console.log('sha256 cryptojs:', CryptoJS.SHA256(msg).toString());
+  try {
+    // enc helpers
+    const utf8Bytes = CryptoWeb.enc.Utf8.parse('hello');
+    assert.strictEqual(CryptoWeb.enc.Utf8.stringify(utf8Bytes), 'hello');
 
-  // Test pbkdf2
-  const keySize = 8; // 8 words = 256 bits
-  const iter = 1000;
-  const keyWrapper = await CryptoWeb.PBKDF2('password', 'salt', { keySize, iterations: iter });
-  const keyCryptoJS = CryptoJS.PBKDF2('password', 'salt', {
-    keySize,
-    iterations: iter,
-    hasher: CryptoJS.algo.SHA256
-  }).toString();
-  console.log('pbkdf2 wrapper:', keyWrapper.toString());
-  console.log('pbkdf2 cryptojs:', keyCryptoJS);
+    const hexStr = CryptoWeb.enc.Hex.stringify(utf8Bytes);
+    assert.strictEqual(hexStr, '68656c6c6f');
+    assert.strictEqual(CryptoWeb.enc.Hex.stringify(CryptoWeb.enc.Hex.parse(hexStr)), hexStr);
 
-  // AES
-  const keyHex = keyWrapper.toString();
-  const plaintext = 'Secret Message';
-  const enc = await CryptoWeb.AES.encrypt(plaintext, keyHex);
-  console.log('aes encrypt wrapper:', enc.toString());
-  const dec = await CryptoWeb.AES.decrypt(enc.toString(), keyHex);
-  console.log('aes decrypt wrapper:', dec.toString());
+    const b64Str = CryptoWeb.enc.Base64.stringify(utf8Bytes);
+    assert.strictEqual(b64Str, Buffer.from('hello').toString('base64'));
+    assert.strictEqual(CryptoWeb.enc.Base64.stringify(CryptoWeb.enc.Base64.parse(b64Str)), b64Str);
+
+    // SHA256
+    const msg = 'Hello World';
+    const hashW = await CryptoWeb.SHA256(msg);
+    const hashC = CryptoJS.SHA256(msg).toString();
+    assert.strictEqual(hashW.toString(), hashC);
+
+    // PBKDF2
+    const keySize = 8; // 8 words = 256 bits
+    const iterations = 1000;
+    const keyWrapper = await CryptoWeb.PBKDF2('password', 'salt', { keySize, iterations });
+    const keyCryptoJS = CryptoJS.PBKDF2('password', 'salt', {
+      keySize,
+      iterations,
+      hasher: CryptoJS.algo.SHA256
+    }).toString();
+    assert.strictEqual(keyWrapper.toString(), keyCryptoJS);
+
+    // AES encrypt/decrypt
+    const keyHex = keyWrapper.toString();
+    const plaintext = 'Secret Message';
+    const enc = await CryptoWeb.AES.encrypt(plaintext, keyHex);
+    const dec = await CryptoWeb.AES.decrypt(enc.toString(), keyHex);
+    assert.strictEqual(dec.toString(), plaintext);
+
+    const encObj = await CryptoWeb.AES.encrypt(plaintext, keyHex);
+    const decObj = await CryptoWeb.AES.decrypt(encObj, keyHex);
+    assert.strictEqual(decObj.toString(), plaintext);
+
+    console.log('All tests passed.');
+  } catch (err) {
+    console.error('Test failed:', err);
+    process.exit(1);
+  }
 })();


### PR DESCRIPTION
## Summary
- make test script run all APIs and fail on error
- run `npm test` from workflow
- ensure `npm test` runs `node test.js`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6879e8c1ee3483208c29c8510a4cadbb