### PR TITLE
Add PBKDF2 defaults test

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@
 
   /* PBKDF2 --------------------------------------------------------------- */
   async function PBKDF2(password, salt, cfg = {}) {
-    const { iterations = 1000, keySize = 256 / 32, hash = 'SHA-256' } = cfg;
+    const { iterations = 250000, keySize = 128 / 32, hash = 'SHA-256' } = cfg;
     const passBytes = typeof password === 'string' ? enc.Utf8.parse(password) : password;
     const saltBytes = typeof salt === 'string' ? enc.Utf8.parse(salt) : salt;
     const baseKey = await subtle.importKey('raw', passBytes, 'PBKDF2', false, ['deriveBits']);

--- a/test.js
+++ b/test.js
@@ -45,6 +45,12 @@ async function runCryptoWebTests() {
     assert.strictEqual(hashW.toString(), hashC);
   });
 
+  await runTest('PBKDF2 default options', async () => {
+    const keyW = await CryptoWeb.PBKDF2('password', 'salt');
+    const keyC = CryptoJS.PBKDF2('password', 'salt').toString();
+    assert.strictEqual(keyW.toString(), keyC);
+  });
+
   let keyWrapper;
   await runTest('PBKDF2', async () => {
     const keySize = 8; // 8 words = 256 bits


### PR DESCRIPTION
## Summary
- align PBKDF2 defaults with CryptoJS
- verify CryptoWeb PBKDF2 matches CryptoJS when using defaults

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879f97737448320b358b93630a0b03f