### PR TITLE
Align AES encrypt with CryptoJS passphrase output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WebCryptoWrapper
 
-crypto-js 互換の入出力を得られる簡単なラッパーです。ブラウザでは Web Crypto API、Node.js では `crypto.webcrypto.subtle` を利用します。IV を暗号文の先頭に連結するため、CryptoJS と同様に文字列だけで復号できます。
+crypto-js 互換の入出力を得られる簡単なラッパーです。ブラウザでは Web Crypto API、Node.js では `crypto.webcrypto.subtle` を利用します。AES 暗号化では、パスフレーズを与えた場合は CryptoJS と同じ "Salted__" 形式の文字列を返し、鍵（16〜32 バイトの値）を与えた場合は暗号文のみを返します。後者を復号する際には IV を渡す必要があります。
 
 ## 使い方
 
@@ -19,9 +19,15 @@ const CryptoWeb = require('./index');
   const enc = await CryptoWeb.AES.encrypt('hello', key);
   console.log(enc.toString());
 
-  // AES 復号
-  const dec = await CryptoWeb.AES.decrypt(enc.toString(), key);
+  // AES 復号（IV を指定）
+  const dec = await CryptoWeb.AES.decrypt(enc.toString(), key, { iv: enc.iv });
   console.log(dec.toString());
+
+  // パスフレーズで AES 暗号化
+  const pwEnc = await CryptoWeb.AES.encrypt('hello', 'secret key 123');
+  console.log(pwEnc.toString()); // CryptoJS と同じ値
+  const pwDec = await CryptoWeb.AES.decrypt(pwEnc.toString(), 'secret key 123');
+  console.log(pwDec.toString());
 
   // SHA-256
   const hash = await CryptoWeb.SHA256('message');


### PR DESCRIPTION
## Summary
- support CryptoJS-style passphrase encryption including OpenSSL salt format
- use Node's `crypto` for MD5 and fall back to JS implementation
- document passphrase usage in README
- update tests to cover passphrase compatibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687a02d9ddec83208cc8c7e8b1046dd6