### PR TITLE
Add SHA1, SHA384, SHA512 hash APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ const CryptoWeb = require('./index');
   const pwDec = await CryptoWeb.AES.decrypt(pwEnc.toString(), 'secret key 123');
   console.log(pwDec.toString());
 
-  // SHA-256
+  // SHA-256 など各種ハッシュ
   const hash = await CryptoWeb.SHA256('message');
   console.log(hash.toString());
 })();
@@ -59,7 +59,7 @@ const CryptoWeb = require('./index');
 - `PBKDF2(password, salt, options)` — WebCrypto の PBKDF2 を使った鍵導出
 - `AES.encrypt(data, key, options)` — AES-CBC による暗号化
 - `AES.decrypt(ciphertext, key, options)` — AES-CBC による復号
-- `SHA256(data)` — SHA-256 ハッシュ計算
+- `SHA1(data)`, `SHA256(data)`, `SHA384(data)`, `SHA512(data)` — 各種 SHA ハッシュ計算
 
 各関数は Promise を返し、戻り値は `toString()` メソッドを持つ CryptoJS 互換の
 オブジェクトです。

--- a/README_en.md
+++ b/README_en.md
@@ -39,7 +39,7 @@ const CryptoWeb = require('./index');
   const pwDec = await CryptoWeb.AES.decrypt(pwEnc.toString(), 'secret key 123');
   console.log(pwDec.toString());
 
-  // SHA-256
+  // SHA-256 and other hash functions
   const hash = await CryptoWeb.SHA256('message');
   console.log(hash.toString());
 })();
@@ -51,7 +51,7 @@ const CryptoWeb = require('./index');
 - `PBKDF2(password, salt, options)` — key derivation using WebCrypto's PBKDF2
 - `AES.encrypt(data, key, options)` — AES-CBC encryption
 - `AES.decrypt(ciphertext, key, options)` — AES-CBC decryption
-- `SHA256(data)` — SHA-256 hash calculation
+- `SHA1(data)`, `SHA256(data)`, `SHA384(data)`, `SHA512(data)` — SHA hash calculations
 
 Each function returns a Promise and the result is a CryptoJS compatible object with a `toString()` method.
 

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
  *
  * A small wrapper around the Web Crypto API and Node.js crypto module.
  * Provides CryptoJS compatible helpers for encoding, PBKDF2, AES-CBC and
- * SHA-256 operations.
+ * SHA-1/256/384/512 hash operations.
  * @namespace CryptoWeb
  */
 (function (root, factory) {
@@ -294,10 +294,26 @@
     }
   };
 
-  /* SHA-256 -------------------------------------------------------------- */
+  /* SHA hashes ----------------------------------------------------------- */
+  /**
+   * Compute SHA-1 digest of data.
+   * @param {string|Uint8Array} data - Data to hash.
+   * @returns {Promise<{words: Uint8Array, sigBytes: number, toString: function}>}
+   *   Promise resolving to a CryptoJS compatible hash object.
+   */
+  async function SHA1(data) {
+    const bytes = typeof data === 'string' ? enc.Utf8.parse(data) : data;
+    const digest = await subtle.digest('SHA-1', bytes);
+    const res = new Uint8Array(digest);
+    return {
+      words: res,
+      sigBytes: res.length,
+      toString(encoder = enc.Hex) { return encoder.stringify(res); }
+    };
+  }
+
   /**
    * Compute SHA-256 digest of data.
-   *
    * @param {string|Uint8Array} data - Data to hash.
    * @returns {Promise<{words: Uint8Array, sigBytes: number, toString: function}>}
    *   Promise resolving to a CryptoJS compatible hash object.
@@ -314,8 +330,43 @@
   }
 
   /**
-   * Exposed API providing encoding utilities and cryptographic functions.
-   * @type {{enc: object, PBKDF2: Function, AES: object, SHA256: Function}}
+   * Compute SHA-384 digest of data.
+   * @param {string|Uint8Array} data - Data to hash.
+   * @returns {Promise<{words: Uint8Array, sigBytes: number, toString: function}>}
+   *   Promise resolving to a CryptoJS compatible hash object.
    */
-  return { enc, PBKDF2, AES, SHA256 };
+  async function SHA384(data) {
+    const bytes = typeof data === 'string' ? enc.Utf8.parse(data) : data;
+    const digest = await subtle.digest('SHA-384', bytes);
+    const res = new Uint8Array(digest);
+    return {
+      words: res,
+      sigBytes: res.length,
+      toString(encoder = enc.Hex) { return encoder.stringify(res); }
+    };
+  }
+
+  /**
+   * Compute SHA-512 digest of data.
+   * @param {string|Uint8Array} data - Data to hash.
+   * @returns {Promise<{words: Uint8Array, sigBytes: number, toString: function}>}
+   *   Promise resolving to a CryptoJS compatible hash object.
+   */
+  async function SHA512(data) {
+    const bytes = typeof data === 'string' ? enc.Utf8.parse(data) : data;
+    const digest = await subtle.digest('SHA-512', bytes);
+    const res = new Uint8Array(digest);
+    return {
+      words: res,
+      sigBytes: res.length,
+      toString(encoder = enc.Hex) { return encoder.stringify(res); }
+    };
+  }
+
+  /**
+   * Exposed API providing encoding utilities and cryptographic functions.
+   * @type {{enc: object, PBKDF2: Function, AES: object,
+   *         SHA1: Function, SHA256: Function, SHA384: Function, SHA512: Function}}
+   */
+  return { enc, PBKDF2, AES, SHA1, SHA256, SHA384, SHA512 };
 }));

--- a/test.js
+++ b/test.js
@@ -53,6 +53,30 @@ async function runCryptoWebTests() {
     assert.strictEqual(hashW.toString(), hashC);
   });
 
+  // SHA1 ハッシュの計算が CryptoJS と一致するか
+  await runTest('SHA1 hash', async () => {
+    const msg = 'Hello World';
+    const hashW = await CryptoWeb.SHA1(msg);
+    const hashC = CryptoJS.SHA1(msg).toString();
+    assert.strictEqual(hashW.toString(), hashC);
+  });
+
+  // SHA384 ハッシュの計算が CryptoJS と一致するか
+  await runTest('SHA384 hash', async () => {
+    const msg = 'Hello World';
+    const hashW = await CryptoWeb.SHA384(msg);
+    const hashC = CryptoJS.SHA384(msg).toString();
+    assert.strictEqual(hashW.toString(), hashC);
+  });
+
+  // SHA512 ハッシュの計算が CryptoJS と一致するか
+  await runTest('SHA512 hash', async () => {
+    const msg = 'Hello World';
+    const hashW = await CryptoWeb.SHA512(msg);
+    const hashC = CryptoJS.SHA512(msg).toString();
+    assert.strictEqual(hashW.toString(), hashC);
+  });
+
   // PBKDF2 のデフォルト設定で生成した鍵が CryptoJS と一致するか
   await runTest('PBKDF2 default options', async () => {
     const keyW = await CryptoWeb.PBKDF2('password', 'salt');


### PR DESCRIPTION
## Summary
- implement SHA1, SHA384 and SHA512 helpers
- document the new API in Japanese and English READMEs
- extend tests to cover the added hash algorithms

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b8723ed448320a6611f2dded2d42d