### PR TITLE
Add MD5 hashing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ const CryptoWeb = require('./index');
   // SHA-256 など各種ハッシュ
   const hash = await CryptoWeb.SHA256('message');
   console.log(hash.toString());
+  const md5 = await CryptoWeb.MD5('message');
+  console.log(md5.toString());
 })();
 ```
 
@@ -60,6 +62,7 @@ const CryptoWeb = require('./index');
 - `AES.encrypt(data, key, options)` — AES-CBC による暗号化
 - `AES.decrypt(ciphertext, key, options)` — AES-CBC による復号
 - `SHA1(data)`, `SHA256(data)`, `SHA384(data)`, `SHA512(data)` — 各種 SHA ハッシュ計算
+- `MD5(data)` — MD5 ハッシュ計算
 
 各関数は Promise を返し、戻り値は `toString()` メソッドを持つ CryptoJS 互換の
 オブジェクトです。

--- a/README_en.md
+++ b/README_en.md
@@ -42,6 +42,8 @@ const CryptoWeb = require('./index');
   // SHA-256 and other hash functions
   const hash = await CryptoWeb.SHA256('message');
   console.log(hash.toString());
+  const md5 = await CryptoWeb.MD5('message');
+  console.log(md5.toString());
 })();
 ```
 
@@ -52,6 +54,7 @@ const CryptoWeb = require('./index');
 - `AES.encrypt(data, key, options)` — AES-CBC encryption
 - `AES.decrypt(ciphertext, key, options)` — AES-CBC decryption
 - `SHA1(data)`, `SHA256(data)`, `SHA384(data)`, `SHA512(data)` — SHA hash calculations
+- `MD5(data)` — MD5 hash calculation
 
 Each function returns a Promise and the result is a CryptoJS compatible object with a `toString()` method.
 

--- a/index.js
+++ b/index.js
@@ -364,9 +364,31 @@
   }
 
   /**
+   * Compute MD5 digest of data.
+   * @param {string|Uint8Array} data - Data to hash.
+   * @returns {Promise<{words: Uint8Array, sigBytes: number, toString: function}>}
+   *   Promise resolving to a CryptoJS compatible hash object.
+   */
+  async function MD5(data) {
+    const bytes = typeof data === 'string' ? enc.Utf8.parse(data) : data;
+    let res;
+    if (nodeCrypto && nodeCrypto.createHash) {
+      res = new Uint8Array(nodeCrypto.createHash('md5').update(Buffer.from(bytes)).digest());
+    } else {
+      res = md5(bytes);
+    }
+    return {
+      words: res,
+      sigBytes: res.length,
+      toString(encoder = enc.Hex) { return encoder.stringify(res); }
+    };
+  }
+
+  /**
    * Exposed API providing encoding utilities and cryptographic functions.
    * @type {{enc: object, PBKDF2: Function, AES: object,
+   *         MD5: Function,
    *         SHA1: Function, SHA256: Function, SHA384: Function, SHA512: Function}}
    */
-  return { enc, PBKDF2, AES, SHA1, SHA256, SHA384, SHA512 };
+  return { enc, PBKDF2, AES, MD5, SHA1, SHA256, SHA384, SHA512 };
 }));

--- a/test.js
+++ b/test.js
@@ -77,6 +77,14 @@ async function runCryptoWebTests() {
     assert.strictEqual(hashW.toString(), hashC);
   });
 
+  // MD5 ハッシュの計算が CryptoJS と一致するか
+  await runTest('MD5 hash', async () => {
+    const msg = 'Hello World';
+    const hashW = await CryptoWeb.MD5(msg);
+    const hashC = CryptoJS.MD5(msg).toString();
+    assert.strictEqual(hashW.toString(), hashC);
+  });
+
   // PBKDF2 のデフォルト設定で生成した鍵が CryptoJS と一致するか
   await runTest('PBKDF2 default options', async () => {
     const keyW = await CryptoWeb.PBKDF2('password', 'salt');


### PR DESCRIPTION
## Summary
- implement `MD5` API and expose it
- document MD5 usage and API in README and README_en
- add tests validating MD5 against crypto-js

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b88e9a8988320b647531de1139d1d