### PR TITLE
Support IV in AES strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ WebCryptoWrapper は、ブラウザの **Web Crypto API** と Node.js の `crypt
 CryptoJS ベースのコードをほぼそのまま流用できます。
 
 AES 暗号化ではパスフレーズを用いた場合に "Salted__" から始まる CryptoJS 形式の
-文字列を返し、16〜32 バイトの鍵を直接指定した場合には暗号文のみを返します。
-後者を復号する際には別途 IV を渡す必要があります。
+文字列を返し、16〜32 バイトの鍵を直接指定した場合には IV を暗号文の前に付加した
+文字列が返されるため、復号時に IV を別途渡す必要はありません。
 
 ## インストール
 
@@ -37,8 +37,8 @@ const CryptoWeb = require('./index');
   const enc = await CryptoWeb.AES.encrypt('hello', key);
   console.log(enc.toString());
 
-  // AES 復号（IV を指定）
-  const dec = await CryptoWeb.AES.decrypt(enc.toString(), key, { iv: enc.iv });
+  // AES 復号
+  const dec = await CryptoWeb.AES.decrypt(enc.toString(), key);
   console.log(dec.toString());
 
   // パスフレーズで AES 暗号化

--- a/README_en.md
+++ b/README_en.md
@@ -2,7 +2,7 @@
 
 WebCryptoWrapper is a lightweight wrapper that provides a consistent interface for the browser **Web Crypto API** and Node.js `crypto.webcrypto`. It aligns the invocation style and input/output with [crypto-js](https://github.com/brix/crypto-js) so that existing CryptoJS-based code can be reused with minimal changes.
 
-When AES encryption is performed with a passphrase, it returns a CryptoJS-formatted string beginning with "Salted__". When a 16–32 byte key is specified directly, only the ciphertext is returned. Decrypting the latter requires the IV to be passed separately.
+When AES encryption is performed with a passphrase, it returns a CryptoJS-formatted string beginning with "Salted__". When a 16–32 byte key is specified directly, the IV is prepended to the ciphertext so that decryption can be performed from the string alone.
 
 ## Installation
 
@@ -29,8 +29,8 @@ const CryptoWeb = require('./index');
   const enc = await CryptoWeb.AES.encrypt('hello', key);
   console.log(enc.toString());
 
-  // AES decryption (provide IV)
-  const dec = await CryptoWeb.AES.decrypt(enc.toString(), key, { iv: enc.iv });
+  // AES decryption
+  const dec = await CryptoWeb.AES.decrypt(enc.toString(), key);
   console.log(dec.toString());
 
   // AES encryption with passphrase

--- a/__tests__/crypto-web.spec.js
+++ b/__tests__/crypto-web.spec.js
@@ -175,7 +175,7 @@ describe.each(envs)('CryptoWeb in %s', (name, getCrypto) => {
     expect(cjDec.toString(CryptoJS.enc.Utf8)).toBe('secret');
 
     const cjEncSame = CryptoJS.AES.encrypt('secret', CryptoJS.enc.Hex.parse(keyHex), { iv: cwIvWA });
-    expect(cwEnc.toString()).toBe(cjEncSame.toString());
+    expect(cwEnc.ciphertext.toString(CryptoWeb.enc.Base64)).toBe(cjEncSame.toString());
 
     const cjEnc = CryptoJS.AES.encrypt('secret', CryptoJS.enc.Hex.parse(keyHex), { iv: cwIvWA });
     const webDec = await CryptoWeb.AES.decrypt(cjEnc.toString(), keyHex, { iv: ivHex });
@@ -242,6 +242,13 @@ describe.each(envs)('Additional CryptoWeb cases in %s', (name, getCrypto) => {
     const enc = await CryptoWeb.AES.encrypt('x', key);
     const dec = await CryptoWeb.AES.decrypt(enc, key);
     expect(dec.toString()).toBe('x');
+  });
+
+  test('AES string round trip with embedded IV', async () => {
+    const key = '00112233445566778899aabbccddeeff';
+    const enc = await CryptoWeb.AES.encrypt('hello', key);
+    const dec = await CryptoWeb.AES.decrypt(enc.toString(), key);
+    expect(dec.toString()).toBe('hello');
   });
 
   test('AES decrypt with wrong key or IV fails', async () => {

--- a/src/index.js
+++ b/src/index.js
@@ -241,7 +241,10 @@
             all.set(cipherBytes, prefix.length + saltBytes.length);
             return encoder.stringify(all);
           }
-          return encoder.stringify(cipherBytes);
+          const all = new Uint8Array(ivBytes.length + cipherBytes.length);
+          all.set(ivBytes);
+          all.set(cipherBytes, ivBytes.length);
+          return encoder.stringify(all);
         }
       };
     },
@@ -263,6 +266,9 @@
         const all = enc.Base64.parse(ciphertext);
         if (all.length >= 16 && enc.Utf8.stringify(all.slice(0, 8)) === 'Salted__') {
           saltBytes = all.slice(8, 16);
+          ctBytes = all.slice(16);
+        } else if (all.length > 16) {
+          ivBytes = all.slice(0, 16);
           ctBytes = all.slice(16);
         } else {
           ctBytes = all;


### PR DESCRIPTION
## Summary
- include the IV when calling `AES.encrypt(...).toString()` with a raw key
- detect prepended IV in `AES.decrypt`
- document new behaviour in README and README_en
- update CryptoWeb<->CryptoJS test and add round-trip test using the new format

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687efdb866e88320a4be2470e529ab3b