### PR TITLE
Update coverage badge on push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   test:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -14,3 +16,15 @@ jobs:
           node-version: '20'
       - run: npm install
       - run: npm test
+      - name: Commit coverage badge
+        if: github.event_name == 'push'
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add coverage/badges.svg
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: update coverage badge [skip ci]"
+            git push
+          fi

--- a/coverage/badges.svg
+++ b/coverage/badges.svg
@@ -1,14 +1,14 @@
 <svg width="114.3" height="20" viewBox="0 0 1143 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="coverage: 93.48%">
   <title>coverage: 93.48%</title>
-  <linearGradient id="SlZfe" x2="0" y2="100%">
+  <linearGradient id="qMIzF" x2="0" y2="100%">
     <stop offset="0" stop-opacity=".1" stop-color="#EEE"/>
     <stop offset="1" stop-opacity=".1"/>
   </linearGradient>
-  <mask id="QhKNN"><rect width="1143" height="200" rx="30" fill="#FFF"/></mask>
-  <g mask="url(#QhKNN)">
+  <mask id="ksRxO"><rect width="1143" height="200" rx="30" fill="#FFF"/></mask>
+  <g mask="url(#ksRxO)">
     <rect width="603" height="200" fill="#555"/>
     <rect width="540" height="200" fill="#97c40f" x="603"/>
-    <rect width="1143" height="200" fill="url(#SlZfe)"/>
+    <rect width="1143" height="200" fill="url(#qMIzF)"/>
   </g>
   <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
     <text x="60" y="148" textLength="503" fill="#000" opacity="0.25">coverage</text>


### PR DESCRIPTION
## Summary
- enable GitHub Actions job to commit updated coverage badge after tests
- regenerate coverage badge

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f74b0ba248320bbdc9a3757709fc8