### PR TITLE
Add invalid input tests

### DIFF
--- a/__tests__/aes_errors.test.js
+++ b/__tests__/aes_errors.test.js
@@ -15,9 +15,13 @@ describe.each(envs)('AES error/boundary cases in %s', (name, getCrypto) => {
     await expect(CryptoWeb.AES.encrypt('x', new Uint8Array(5))).rejects.toThrow('Key length');
     await expect(CryptoWeb.AES.decrypt('abcd', 'deadbeef')).rejects.toThrow('salt required');
     const keyHex = '00112233445566778899aabbccddeeff';
+    await expect(CryptoWeb.AES.encrypt(null, keyHex)).rejects.toThrow();
+    await expect(CryptoWeb.AES.encrypt(undefined, keyHex)).rejects.toThrow();
     await expect(CryptoWeb.AES.decrypt('abcd', keyHex)).rejects.toThrow('IV required');
     await expect(CryptoWeb.AES.decrypt({ ciphertext: new Uint8Array([1,2,3]) }, keyHex)).rejects.toThrow('IV required');
     await expect(CryptoWeb.AES.decrypt(null, keyHex)).rejects.toThrow('invalid ciphertext');
+    await expect(CryptoWeb.AES.decrypt(undefined, keyHex)).rejects.toThrow('invalid ciphertext');
+    await expect(CryptoWeb.AES.decrypt(new Uint8Array(0), keyHex)).rejects.toThrow('invalid ciphertext');
   });
 
   test('getRandomValues instance reused for IV', async () => {
@@ -38,6 +42,13 @@ describe.each(envs)('AES error/boundary cases in %s', (name, getCrypto) => {
     expect(enc.ciphertext.words.length).toBe(16);
     const dec = await CryptoWeb.AES.decrypt(enc, key);
     expect(dec.toString()).toBe('');
+  });
+
+  test('AES empty array round trip', async () => {
+    const key = '00112233445566778899aabbccddeeff';
+    const enc = await CryptoWeb.AES.encrypt(new Uint8Array(0), key);
+    const dec = await CryptoWeb.AES.decrypt(enc, key);
+    expect(dec.words.length).toBe(0);
   });
 
   test('AES auto IV round trip', async () => {

--- a/__tests__/enc.test.js
+++ b/__tests__/enc.test.js
@@ -24,4 +24,16 @@ describe.each(envs)('Encoding helpers in %s', (name, getCrypto) => {
   test('Base64.parse throws on invalid input', () => {
     expect(() => CryptoWeb.enc.Base64.parse('$!')).toThrow();
   });
+
+  test('encoding helpers invalid input', () => {
+    expect(() => CryptoWeb.enc.Hex.parse(null)).toThrow();
+    expect(() => CryptoWeb.enc.Hex.stringify(null)).toThrow();
+    expect(() => CryptoWeb.enc.Base64.parse(undefined)).toThrow();
+    expect(() => CryptoWeb.enc.Base64.stringify(undefined)).toThrow();
+    expect(() => CryptoWeb.enc.Utf8.stringify(null)).toThrow();
+    expect(CryptoWeb.enc.Utf8.parse(undefined).length).toBe(0);
+    expect(CryptoWeb.enc.Hex.stringify([])).toBe('');
+    expect(CryptoWeb.enc.Base64.stringify([])).toBe('');
+    expect(CryptoWeb.enc.Utf8.stringify(new Uint8Array(0))).toBe('');
+  });
 });

--- a/__tests__/hash.test.js
+++ b/__tests__/hash.test.js
@@ -34,4 +34,13 @@ describe.each(envs)('Hash functions in %s', (name, getCrypto) => {
     expect((await CryptoWeb.MD5('abc')).toString()).toBe(vectors.hash.md5.abc);
     expect((await CryptoWeb.MD5(long)).toString()).toBe(vectors.hash.md5.long);
   });
+
+  test('hash invalid input and empty arrays', async () => {
+    await expect(CryptoWeb.SHA1(null)).rejects.toThrow();
+    await expect(CryptoWeb.SHA256(undefined)).rejects.toThrow();
+    await expect(CryptoWeb.SHA512([])).rejects.toThrow();
+    const empty = new Uint8Array(0);
+    expect((await CryptoWeb.SHA1(empty)).toString()).toBe(vectors.hash.sha1['']);
+    expect((await CryptoWeb.MD5(empty)).toString()).toBe('d41d8cd98f00b204e9800998ecf8427e');
+  });
 });

--- a/__tests__/pbkdf2.test.js
+++ b/__tests__/pbkdf2.test.js
@@ -44,4 +44,14 @@ describe.each(envs)('PBKDF2 in %s', (name, getCrypto) => {
     const res = await CryptoWeb.PBKDF2('p', 's', { iterations: 1, keySize: 0 });
     expect(res.words.length).toBe(0);
   });
+
+  test('PBKDF2 null/undefined salt rejects', async () => {
+    await expect(CryptoWeb.PBKDF2('p', null)).rejects.toThrow();
+    await expect(CryptoWeb.PBKDF2('p', undefined)).rejects.toThrow();
+  });
+
+  test('PBKDF2 empty salt works', async () => {
+    const res = await CryptoWeb.PBKDF2('p', new Uint8Array(0), { iterations: 1 });
+    expect(res.words.length).toBe(16);
+  });
 });


### PR DESCRIPTION
## Summary
- test encoding helpers with null/undefined/empty data
- test PBKDF2 invalid salt and empty salt
- test AES encrypt/decrypt with mismatched types and empty arrays
- test hashes with invalid input and empty arrays

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f7a8af9e08320870d116a10df3dbb