### PR TITLE
Add array-like tests for crypto functions

### DIFF
--- a/__tests__/aes_cbc_core.test.js
+++ b/__tests__/aes_cbc_core.test.js
@@ -53,4 +53,16 @@ describe.each(envs)('AES core in %s', (name, getCrypto) => {
     const dec = await CryptoWeb.AES.decrypt(enc, key);
     expect(dec.toString()).toBe(str);
   });
+
+  test('AES encrypt/decrypt with Buffer', async () => {
+    const v = vectors.aesCbc[0];
+    const pt = Buffer.from(v.pt, 'hex');
+    const key = Buffer.from(v.key, 'hex');
+    const iv = Buffer.from(v.iv, 'hex');
+    const enc = await CryptoWeb.AES.encrypt(pt, key, { iv });
+    const hex = enc.ciphertext.toString(CryptoWeb.enc.Hex);
+    expect(hex.slice(0, v.ct.length)).toBe(v.ct);
+    const dec = await CryptoWeb.AES.decrypt(enc, key);
+    expect(CryptoWeb.enc.Hex.stringify(dec.words)).toBe(v.pt);
+  });
 });

--- a/__tests__/aes_errors.test.js
+++ b/__tests__/aes_errors.test.js
@@ -15,6 +15,8 @@ describe.each(envs)('AES error/boundary cases in %s', (name, getCrypto) => {
     await expect(CryptoWeb.AES.encrypt('x', new Uint8Array(5))).rejects.toThrow('Key length');
     await expect(CryptoWeb.AES.decrypt('abcd', 'deadbeef')).rejects.toThrow('salt required');
     const keyHex = '00112233445566778899aabbccddeeff';
+    await expect(CryptoWeb.AES.encrypt([1,2,3], keyHex)).rejects.toThrow();
+    await expect(CryptoWeb.AES.decrypt({ ciphertext: [1,2,3], iv: '000102030405060708090a0b0c0d0e0f' }, keyHex)).rejects.toThrow();
     await expect(CryptoWeb.AES.encrypt(null, keyHex)).rejects.toThrow();
     await expect(CryptoWeb.AES.encrypt(undefined, keyHex)).rejects.toThrow();
     await expect(CryptoWeb.AES.decrypt('abcd', keyHex)).rejects.toThrow('IV required');

--- a/__tests__/enc.test.js
+++ b/__tests__/enc.test.js
@@ -36,4 +36,15 @@ describe.each(envs)('Encoding helpers in %s', (name, getCrypto) => {
     expect(CryptoWeb.enc.Base64.stringify([])).toBe('');
     expect(CryptoWeb.enc.Utf8.stringify(new Uint8Array(0))).toBe('');
   });
+
+  test('encoding helpers with ArrayLike input', () => {
+    const bytes = [0x68, 0x69];
+    const buf = Buffer.from(bytes);
+    expect(CryptoWeb.enc.Hex.stringify(buf)).toBe('6869');
+    expect(CryptoWeb.enc.Hex.stringify(bytes)).toBe('6869');
+    expect(CryptoWeb.enc.Base64.stringify(buf)).toBe('aGk=');
+    expect(CryptoWeb.enc.Base64.stringify(bytes)).toBe('aGk=');
+    expect(CryptoWeb.enc.Utf8.stringify(buf)).toBe('hi');
+    expect(() => CryptoWeb.enc.Utf8.stringify(bytes)).toThrow();
+  });
 });

--- a/__tests__/hash.test.js
+++ b/__tests__/hash.test.js
@@ -43,4 +43,15 @@ describe.each(envs)('Hash functions in %s', (name, getCrypto) => {
     expect((await CryptoWeb.SHA1(empty)).toString()).toBe(vectors.hash.sha1['']);
     expect((await CryptoWeb.MD5(empty)).toString()).toBe('d41d8cd98f00b204e9800998ecf8427e');
   });
+
+  test('hash with Buffer input and Array rejects', async () => {
+    const buf = Buffer.from('abc');
+    expect((await CryptoWeb.SHA1(buf)).toString()).toBe(vectors.hash.sha1.abc);
+    expect((await CryptoWeb.SHA256(buf)).toString()).toBe(vectors.hash.sha256.abc);
+    expect((await CryptoWeb.SHA384(buf)).toString()).toBe(vectors.hash.sha384.abc);
+    expect((await CryptoWeb.SHA512(buf)).toString()).toBe(vectors.hash.sha512.abc);
+    expect((await CryptoWeb.MD5(buf)).toString()).toBe(vectors.hash.md5.abc);
+    await expect(CryptoWeb.SHA1([1,2,3])).rejects.toThrow();
+    expect((await CryptoWeb.MD5([0x61,0x62,0x63])).toString()).toBe(vectors.hash.md5.abc);
+  });
 });

--- a/__tests__/pbkdf2.test.js
+++ b/__tests__/pbkdf2.test.js
@@ -54,4 +54,13 @@ describe.each(envs)('PBKDF2 in %s', (name, getCrypto) => {
     const res = await CryptoWeb.PBKDF2('p', new Uint8Array(0), { iterations: 1 });
     expect(res.words.length).toBe(16);
   });
+
+  test('PBKDF2 Buffer input and Array rejects', async () => {
+    const bufPass = Buffer.from('password');
+    const bufSalt = Buffer.from('salt');
+    const a = await CryptoWeb.PBKDF2('password', 'salt', { iterations: 1, keySize: 4 });
+    const b = await CryptoWeb.PBKDF2(bufPass, bufSalt, { iterations: 1, keySize: 4 });
+    expect(b.toString()).toBe(a.toString());
+    await expect(CryptoWeb.PBKDF2([1,2,3], [4,5,6], { iterations: 1 })).rejects.toThrow();
+  });
 });

--- a/coverage/badges.svg
+++ b/coverage/badges.svg
@@ -1,20 +1,20 @@
-<svg width="114.3" height="20" viewBox="0 0 1143 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="coverage: 93.48%">
-  <title>coverage: 93.48%</title>
-  <linearGradient id="Zumss" x2="0" y2="100%">
+<svg width="114.3" height="20" viewBox="0 0 1143 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="coverage: 94.41%">
+  <title>coverage: 94.41%</title>
+  <linearGradient id="SrMpF" x2="0" y2="100%">
     <stop offset="0" stop-opacity=".1" stop-color="#EEE"/>
     <stop offset="1" stop-opacity=".1"/>
   </linearGradient>
-  <mask id="WSZxD"><rect width="1143" height="200" rx="30" fill="#FFF"/></mask>
-  <g mask="url(#WSZxD)">
+  <mask id="bQRsX"><rect width="1143" height="200" rx="30" fill="#FFF"/></mask>
+  <g mask="url(#bQRsX)">
     <rect width="603" height="200" fill="#555"/>
     <rect width="540" height="200" fill="#97c40f" x="603"/>
-    <rect width="1143" height="200" fill="url(#Zumss)"/>
+    <rect width="1143" height="200" fill="url(#SrMpF)"/>
   </g>
   <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
     <text x="60" y="148" textLength="503" fill="#000" opacity="0.25">coverage</text>
     <text x="50" y="138" textLength="503">coverage</text>
-    <text x="658" y="148" textLength="440" fill="#000" opacity="0.25">93.48%</text>
-    <text x="648" y="138" textLength="440">93.48%</text>
+    <text x="658" y="148" textLength="440" fill="#000" opacity="0.25">94.41%</text>
+    <text x="648" y="138" textLength="440">94.41%</text>
   </g>
   
 </svg>

--- a/coverage/badges.svg
+++ b/coverage/badges.svg
@@ -1,14 +1,14 @@
 <svg width="114.3" height="20" viewBox="0 0 1143 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="coverage: 94.41%">
   <title>coverage: 94.41%</title>
-  <linearGradient id="SrMpF" x2="0" y2="100%">
+  <linearGradient id="TOryh" x2="0" y2="100%">
     <stop offset="0" stop-opacity=".1" stop-color="#EEE"/>
     <stop offset="1" stop-opacity=".1"/>
   </linearGradient>
-  <mask id="bQRsX"><rect width="1143" height="200" rx="30" fill="#FFF"/></mask>
-  <g mask="url(#bQRsX)">
+  <mask id="ynXKm"><rect width="1143" height="200" rx="30" fill="#FFF"/></mask>
+  <g mask="url(#ynXKm)">
     <rect width="603" height="200" fill="#555"/>
     <rect width="540" height="200" fill="#97c40f" x="603"/>
-    <rect width="1143" height="200" fill="url(#SrMpF)"/>
+    <rect width="1143" height="200" fill="url(#TOryh)"/>
   </g>
   <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
     <text x="60" y="148" textLength="503" fill="#000" opacity="0.25">coverage</text>


### PR DESCRIPTION
## Summary
- cover enc helpers with Buffer and Array input
- test PBKDF2 Buffer input and Array rejection
- verify AES functions work with Buffer and reject plain arrays
- ensure hash functions operate on Buffers and handle arrays appropriately

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f7ddb4ffc83208b1afe789373986a