### PR TITLE
Add encoding edge case tests

### DIFF
--- a/__tests__/enc.test.js
+++ b/__tests__/enc.test.js
@@ -47,4 +47,30 @@ describe.each(envs)('Encoding helpers in %s', (name, getCrypto) => {
     expect(CryptoWeb.enc.Utf8.stringify(buf)).toBe('hi');
     expect(() => CryptoWeb.enc.Utf8.stringify(bytes)).toThrow();
   });
+
+  test('Hex.parse odd length and invalid chars', () => {
+    expect(Array.from(CryptoWeb.enc.Hex.parse('abc')))
+      .toEqual(Array.from(CryptoWeb.enc.Hex.parse('ab')));
+    expect(Array.from(CryptoWeb.enc.Hex.parse('gh'))).toEqual([0]);
+  });
+
+  test('Base64.parse edge cases', () => {
+    const noPad = CryptoWeb.enc.Base64.parse('aGk');
+    expect(CryptoWeb.enc.Utf8.stringify(noPad)).toBe('hi');
+    expect(() => CryptoWeb.enc.Base64.parse('aGk=\naGk=')).toThrow();
+    expect(() => CryptoWeb.enc.Base64.parse('??')).toThrow();
+  });
+
+  test('Utf8 special strings', () => {
+    const nul = CryptoWeb.enc.Utf8.parse('a\0b');
+    expect(nul[1]).toBe(0);
+    expect(CryptoWeb.enc.Utf8.stringify(nul)).toBe('a\0b');
+
+    const invalid = CryptoWeb.enc.Utf8.parse('\uD800');
+    expect(CryptoWeb.enc.Utf8.stringify(invalid)).toBe('\uFFFD');
+
+    const composite = 'A\u030A';
+    const round = CryptoWeb.enc.Utf8.stringify(CryptoWeb.enc.Utf8.parse(composite));
+    expect(round).toBe(composite);
+  });
 });


### PR DESCRIPTION
## Summary
- extend encoding test suite with odd and invalid Hex parsing
- test Base64 parsing of missing padding, invalid characters, and newlines
- verify Utf8 encoding of strings with NUL, lone surrogates, and combining characters

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f82bd964c8320ab70dc12c1db8192