### PR TITLE
Add PBKDF2 test vectors

### DIFF
--- a/__tests__/pbkdf2.test.js
+++ b/__tests__/pbkdf2.test.js
@@ -1,4 +1,5 @@
 const CryptoWeb = require('../src');
+const CryptoJS = require('crypto-js');
 const vectors = require('../vectors');
 const { webcrypto: nodeCrypto } = require('node:crypto');
 
@@ -62,5 +63,51 @@ describe.each(envs)('PBKDF2 in %s', (name, getCrypto) => {
     const b = await CryptoWeb.PBKDF2(bufPass, bufSalt, { iterations: 1, keySize: 4 });
     expect(b.toString()).toBe(a.toString());
     await expect(CryptoWeb.PBKDF2([1,2,3], [4,5,6], { iterations: 1 })).rejects.toThrow();
+  });
+
+  test('PBKDF2 hash algorithm variations', async () => {
+    const vectors = {
+      'SHA-1': '0c60c80f961f0e71f3a9b524af6012062fe037a6',
+      'SHA-256': '120fb6cffcf8b32c43e7225256c4f837a86548c9',
+      'SHA-384': 'c0e14f06e49e32d73f9f52ddf1d0c5c719160923',
+      'SHA-512': '867f70cf1ade02cff3752599a3a53dc4af34c7a6'
+    };
+    for (const [hash, hex] of Object.entries(vectors)) {
+      const res = await CryptoWeb.PBKDF2('password', 'salt', { iterations: 1, keySize: 20 / 4, hash });
+      expect(res.toString()).toBe(hex);
+    }
+  });
+
+  test('PBKDF2 iterations boundary and type', async () => {
+    const a = await CryptoWeb.PBKDF2('p', 's', { iterations: 1, keySize: 4 });
+    const b = await CryptoWeb.PBKDF2('p', 's', { iterations: 1.5, keySize: 4 });
+    expect(b.toString()).toBe(a.toString());
+    await expect(CryptoWeb.PBKDF2('p', 's', { iterations: -1 })).rejects.toThrow();
+  });
+
+  test('PBKDF2 keySize edge cases', async () => {
+    const half = await CryptoWeb.PBKDF2('p', 's', { iterations: 1, keySize: 0.5 });
+    expect(half.words.length).toBe(2);
+    const large = await CryptoWeb.PBKDF2('p', 's', { iterations: 1, keySize: 1024 });
+    expect(large.words.length).toBe(4096);
+  });
+
+  test('PBKDF2 Uint8Array vs string equality', async () => {
+    const passBytes = CryptoWeb.enc.Utf8.parse('pass');
+    const saltBytes = CryptoWeb.enc.Utf8.parse('salt');
+    const a = await CryptoWeb.PBKDF2('pass', 'salt', { iterations: 2, keySize: 4 });
+    const b = await CryptoWeb.PBKDF2(passBytes, saltBytes, { iterations: 2, keySize: 4 });
+    expect(b.toString()).toBe(a.toString());
+  });
+
+  test('PBKDF2 matches CryptoJS implementation', async () => {
+    const opts = { iterations: 10, keySize: 4, hash: 'SHA-256' };
+    const cw = await CryptoWeb.PBKDF2('password', 'salt', opts);
+    const cj = CryptoJS.PBKDF2('password', 'salt', {
+      iterations: opts.iterations,
+      keySize: opts.keySize,
+      hasher: CryptoJS.algo.SHA256
+    });
+    expect(cw.toString()).toBe(cj.toString());
   });
 });

--- a/coverage/badges.svg
+++ b/coverage/badges.svg
@@ -1,14 +1,14 @@
 <svg width="114.3" height="20" viewBox="0 0 1143 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="coverage: 94.41%">
   <title>coverage: 94.41%</title>
-  <linearGradient id="XYKQA" x2="0" y2="100%">
+  <linearGradient id="dcApH" x2="0" y2="100%">
     <stop offset="0" stop-opacity=".1" stop-color="#EEE"/>
     <stop offset="1" stop-opacity=".1"/>
   </linearGradient>
-  <mask id="uZeJn"><rect width="1143" height="200" rx="30" fill="#FFF"/></mask>
-  <g mask="url(#uZeJn)">
+  <mask id="sKSnp"><rect width="1143" height="200" rx="30" fill="#FFF"/></mask>
+  <g mask="url(#sKSnp)">
     <rect width="603" height="200" fill="#555"/>
     <rect width="540" height="200" fill="#97c40f" x="603"/>
-    <rect width="1143" height="200" fill="url(#XYKQA)"/>
+    <rect width="1143" height="200" fill="url(#dcApH)"/>
   </g>
   <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
     <text x="60" y="148" textLength="503" fill="#000" opacity="0.25">coverage</text>

--- a/coverage/badges.svg
+++ b/coverage/badges.svg
@@ -1,14 +1,14 @@
 <svg width="114.3" height="20" viewBox="0 0 1143 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="coverage: 94.41%">
   <title>coverage: 94.41%</title>
-  <linearGradient id="xUOIr" x2="0" y2="100%">
+  <linearGradient id="XYKQA" x2="0" y2="100%">
     <stop offset="0" stop-opacity=".1" stop-color="#EEE"/>
     <stop offset="1" stop-opacity=".1"/>
   </linearGradient>
-  <mask id="qUeEQ"><rect width="1143" height="200" rx="30" fill="#FFF"/></mask>
-  <g mask="url(#qUeEQ)">
+  <mask id="uZeJn"><rect width="1143" height="200" rx="30" fill="#FFF"/></mask>
+  <g mask="url(#uZeJn)">
     <rect width="603" height="200" fill="#555"/>
     <rect width="540" height="200" fill="#97c40f" x="603"/>
-    <rect width="1143" height="200" fill="url(#xUOIr)"/>
+    <rect width="1143" height="200" fill="url(#XYKQA)"/>
   </g>
   <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
     <text x="60" y="148" textLength="503" fill="#000" opacity="0.25">coverage</text>


### PR DESCRIPTION
## Summary
- add CryptoJS import for PBKDF2 comparisons
- extend PBKDF2 test coverage for hash variants and edge cases
- update coverage badge

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f8b9ea7b08320a614c266e0b85724