### PR TITLE
Add AES-CBC test coverage

### DIFF
--- a/__tests__/aes_cbc_core.test.js
+++ b/__tests__/aes_cbc_core.test.js
@@ -65,4 +65,49 @@ describe.each(envs)('AES core in %s', (name, getCrypto) => {
     const dec = await CryptoWeb.AES.decrypt(enc, key);
     expect(CryptoWeb.enc.Hex.stringify(dec.words)).toBe(v.pt);
   });
+
+  test('AES padding round trip', async () => {
+    const key = '00112233445566778899aabbccddeeff';
+    for (const len of [16, 15, 23]) {
+      const data = Uint8Array.from({ length: len }, (_, i) => i);
+      const enc = await CryptoWeb.AES.encrypt(data, key);
+      const dec = await CryptoWeb.AES.decrypt(enc, key);
+      expect(Array.from(dec.words)).toEqual(Array.from(data));
+    }
+  });
+
+  test('passphrase salt variations and CryptoJS compatibility', async () => {
+    const salt = '01020304';
+    const pw = 'pass';
+    const enc = await CryptoWeb.AES.encrypt('hello', pw, { salt });
+    const cjEnc = CryptoJS.AES.encrypt('hello', pw, { salt: CryptoJS.enc.Hex.parse(salt) });
+    expect(enc.toString()).toBe(cjEnc.toString());
+    await expect(CryptoWeb.AES.decrypt(enc.toString(), pw)).rejects.toThrow();
+    const b64 = enc.ciphertext.toString(CryptoWeb.enc.Base64);
+    const dec = await CryptoWeb.AES.decrypt(b64, pw, { salt });
+    expect(dec.toString()).toBe('hello');
+    await expect(CryptoWeb.AES.decrypt(cjEnc.toString(), pw)).rejects.toThrow();
+  });
+
+  test('string ciphertext without IV and cfg.iv priority', async () => {
+    const key = '00112233445566778899aabbccddeeff';
+    const iv = '000102030405060708090a0b0c0d0e0f';
+    const enc = await CryptoWeb.AES.encrypt('hello', key, { iv });
+    const ctOnly = enc.ciphertext.toString(CryptoWeb.enc.Base64);
+    const dec = await CryptoWeb.AES.decrypt(ctOnly, key, { iv });
+    expect(dec.toString()).toBe('hello');
+    const wrong = 'ffeeddccbbaa99887766554433221100';
+    await expect(CryptoWeb.AES.decrypt(enc.toString(), key, { iv: wrong })).rejects.toThrow();
+  });
+
+  test('mixed word array and Uint8Array object input', async () => {
+    const key = '00112233445566778899aabbccddeeff';
+    const enc = await CryptoWeb.AES.encrypt('hi', key);
+    const obj1 = { ciphertext: enc.ciphertext.words, iv: enc.iv };
+    const dec1 = await CryptoWeb.AES.decrypt(obj1, key);
+    expect(dec1.toString()).toBe('hi');
+    const obj2 = { ciphertext: enc.ciphertext, iv: enc.iv.words };
+    const dec2 = await CryptoWeb.AES.decrypt(obj2, key);
+    expect(dec2.toString()).toBe('hi');
+  });
 });

--- a/coverage/badges.svg
+++ b/coverage/badges.svg
@@ -1,20 +1,20 @@
-<svg width="114.3" height="20" viewBox="0 0 1143 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="coverage: 94.41%">
-  <title>coverage: 94.41%</title>
-  <linearGradient id="HajKv" x2="0" y2="100%">
+<svg width="114.3" height="20" viewBox="0 0 1143 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="coverage: 94.88%">
+  <title>coverage: 94.88%</title>
+  <linearGradient id="nNnSZ" x2="0" y2="100%">
     <stop offset="0" stop-opacity=".1" stop-color="#EEE"/>
     <stop offset="1" stop-opacity=".1"/>
   </linearGradient>
-  <mask id="gMRsT"><rect width="1143" height="200" rx="30" fill="#FFF"/></mask>
-  <g mask="url(#gMRsT)">
+  <mask id="RAfgU"><rect width="1143" height="200" rx="30" fill="#FFF"/></mask>
+  <g mask="url(#RAfgU)">
     <rect width="603" height="200" fill="#555"/>
     <rect width="540" height="200" fill="#97c40f" x="603"/>
-    <rect width="1143" height="200" fill="url(#HajKv)"/>
+    <rect width="1143" height="200" fill="url(#nNnSZ)"/>
   </g>
   <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
     <text x="60" y="148" textLength="503" fill="#000" opacity="0.25">coverage</text>
     <text x="50" y="138" textLength="503">coverage</text>
-    <text x="658" y="148" textLength="440" fill="#000" opacity="0.25">94.41%</text>
-    <text x="648" y="138" textLength="440">94.41%</text>
+    <text x="658" y="148" textLength="440" fill="#000" opacity="0.25">94.88%</text>
+    <text x="648" y="138" textLength="440">94.88%</text>
   </g>
   
 </svg>


### PR DESCRIPTION
## Summary
- add padding, passphrase and IV edge case tests for AES-CBC
- check subtle decrypt failure and invalid ciphertext scenarios

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881724f1c6483208e4b9bc7d158697c