### PR TITLE
Add wa helper tests

### DIFF
--- a/__tests__/enc.test.js
+++ b/__tests__/enc.test.js
@@ -72,4 +72,18 @@ describe.each(envs)('Encoding helpers in %s', (name, getCrypto) => {
     const compBytes = CryptoWeb.enc.Utf8.parse(composed);
     expect(CryptoWeb.enc.Utf8.stringify(compBytes)).toBe(composed);
   });
+
+  test('wa default encoder override', () => {
+    const bytes = CryptoWeb.enc.Utf8.parse('hi');
+    const wa = CryptoWeb.wa(bytes, CryptoWeb.enc.Base64);
+    expect(wa.toString()).toBe('aGk=');
+    expect(wa.toString(CryptoWeb.enc.Hex)).toBe('6869');
+  });
+
+  test('wa words reassignment immutability', () => {
+    const orig = CryptoWeb.wa(CryptoWeb.enc.Hex.parse('deadbeef'));
+    const before = orig.toString();
+    orig.words = CryptoWeb.enc.Hex.parse('ffff');
+    expect(orig.toString()).toBe(before);
+  });
 });

--- a/coverage/badges.svg
+++ b/coverage/badges.svg
@@ -1,14 +1,14 @@
 <svg width="114.3" height="20" viewBox="0 0 1143 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="coverage: 94.88%">
   <title>coverage: 94.88%</title>
-  <linearGradient id="IRdBE" x2="0" y2="100%">
+  <linearGradient id="JnrEg" x2="0" y2="100%">
     <stop offset="0" stop-opacity=".1" stop-color="#EEE"/>
     <stop offset="1" stop-opacity=".1"/>
   </linearGradient>
-  <mask id="YMLQP"><rect width="1143" height="200" rx="30" fill="#FFF"/></mask>
-  <g mask="url(#YMLQP)">
+  <mask id="vjcZu"><rect width="1143" height="200" rx="30" fill="#FFF"/></mask>
+  <g mask="url(#vjcZu)">
     <rect width="603" height="200" fill="#555"/>
     <rect width="540" height="200" fill="#97c40f" x="603"/>
-    <rect width="1143" height="200" fill="url(#IRdBE)"/>
+    <rect width="1143" height="200" fill="url(#JnrEg)"/>
   </g>
   <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
     <text x="60" y="148" textLength="503" fill="#000" opacity="0.25">coverage</text>

--- a/src/index.js
+++ b/src/index.js
@@ -406,5 +406,5 @@
    *         MD5: Function,
    *         SHA1: Function, SHA256: Function, SHA384: Function, SHA512: Function}}
    */
-  return { enc, PBKDF2, AES, MD5, SHA1, SHA256, SHA384, SHA512 };
+  return { enc, wa, PBKDF2, AES, MD5, SHA1, SHA256, SHA384, SHA512 };
 }));


### PR DESCRIPTION
## Summary
- add tests for wa default encoder and immutability
- export `wa` helper to use in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881745269cc8320ab61c7c5ae45abaa