### PR TITLE
chore: switch npm Dependabot schedule to explicit daily cron

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,8 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
-      time: "06:00"
+      interval: "cron"
+      cronjob: "0 6 * * *"
       timezone: "Asia/Tokyo"
     groups:
       vitest:


### PR DESCRIPTION
### Motivation
- GitHub's `dependabot` `schedule.interval: "daily"` is weekday-only, so the `npm` checks should be scheduled with an explicit cron to run every calendar day (including weekends).

### Description
- In ` .github/dependabot.yml` the `npm` update entry was changed from `schedule: interval: "daily"`/`time: "06:00"` to `schedule: interval: "cron"` with `cronjob: "0 6 * * *"`, keeping `timezone: "Asia/Tokyo"` and leaving the `github-actions` entry unchanged.

### Testing
- Ran `git diff -- .github/dependabot.yml`, `git status --short`, and `git add .github/dependabot.yml && git commit -m "chore: run npm dependabot updates daily via cron"`, all succeeded; no runtime tests were required for this config-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8ea87da5c83208150504d6efd6295)