### PR TITLE
chore: update checkout action comment to v6.0.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24'


### PR DESCRIPTION
### Motivation
- Align the inline comment for the pinned `actions/checkout` entry in ` .github/workflows/test.yml` to reflect `v6.0.2` instead of `v6.0.0`.

### Description
- Changed the comment on the `- uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd` line in ` .github/workflows/test.yml` from `# v6.0.0` to `# v6.0.2`.

### Testing
- Executed `git diff -- .github/workflows/test.yml` and `git commit -m "chore: update checkout action comment to v6.0.2"`, both commands succeeded; no CI run required for this comment-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fec8c0d1208320ab65f3613b97626a)