### PR TITLE
Strengthen environment-fallback tests and fix JS MD5 padding bug

### DIFF
--- a/__tests__/env_fallbacks.test.js
+++ b/__tests__/env_fallbacks.test.js
@@ -1,29 +1,48 @@
 const { webcrypto: nodeCrypto } = require('node:crypto');
 
+const restoreNodeWebcrypto = () => {
+  global.crypto = nodeCrypto;
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  restoreNodeWebcrypto();
+});
+
 test('randomBytes fallback when getRandomValues missing', async () => {
   vi.resetModules();
   const crypto = require('node:crypto');
   const orig = crypto.webcrypto.getRandomValues;
   crypto.webcrypto.getRandomValues = undefined;
   global.crypto = crypto.webcrypto;
-  const spy = vi.spyOn(crypto, 'randomBytes');
-  const CW = require('../src');
-  await CW.AES.encrypt('x', '00112233445566778899aabbccddeeff');
-  expect(spy).toHaveBeenCalled();
-  spy.mockRestore();
-  crypto.webcrypto.getRandomValues = orig;
-  global.crypto = nodeCrypto;
+  const deterministicIv = Buffer.alloc(16, 0xaa);
+  const spy = vi.spyOn(crypto, 'randomBytes').mockReturnValue(deterministicIv);
+
+  try {
+    const CW = require('../src');
+    const encrypted = await CW.AES.encrypt('x', '00112233445566778899aabbccddeeff');
+
+    expect(spy).toHaveBeenCalledWith(16);
+    expect(encrypted.iv.toString(CW.enc.Hex)).toBe('aa'.repeat(16));
+  } finally {
+    crypto.webcrypto.getRandomValues = orig;
+  }
 });
 
-test('MD5 JavaScript fallback', async () => {
+test('MD5 JavaScript fallback computes the standard digest', async () => {
   vi.resetModules();
   const crypto = require('node:crypto');
   const orig = crypto.createHash;
   delete crypto.createHash;
-  const CW = require('../src');
-  const h = await CW.MD5('abc');
-  expect(h.toString().length).toBe(32);
-  crypto.createHash = orig;
+
+  try {
+    const CW = require('../src');
+    const h = await CW.MD5('abc');
+
+    expect(h.toString()).toBe('900150983cd24fb0d6963f7d28e17f72');
+  } finally {
+    crypto.createHash = orig;
+  }
 });
 
 test('Base64 Buffer fallback when atob/btoa missing', () => {
@@ -32,13 +51,17 @@ test('Base64 Buffer fallback when atob/btoa missing', () => {
   const origBtoa = global.btoa;
   global.atob = undefined;
   global.btoa = undefined;
-  const CW = require('../src');
-  const b64 = CW.enc.Base64.stringify(Uint8Array.from([104, 105]));
-  expect(b64).toBe('aGk=');
-  const bytes = CW.enc.Base64.parse(b64);
-  expect(CW.enc.Utf8.stringify(bytes)).toBe('hi');
-  global.atob = origAtob;
-  global.btoa = origBtoa;
+
+  try {
+    const CW = require('../src');
+    const b64 = CW.enc.Base64.stringify(Uint8Array.from([104, 105]));
+    expect(b64).toBe('aGk=');
+    const bytes = CW.enc.Base64.parse(b64);
+    expect(CW.enc.Utf8.stringify(bytes)).toBe('hi');
+  } finally {
+    global.atob = origAtob;
+    global.btoa = origBtoa;
+  }
 });
 
 test('throws when no secure random generator', async () => {
@@ -49,13 +72,16 @@ test('throws when no secure random generator', async () => {
   crypto.webcrypto.getRandomValues = undefined;
   delete crypto.randomBytes;
   global.crypto = crypto.webcrypto;
-  const CW = require('../src');
-  await expect(
-    CW.AES.encrypt('x', '00112233445566778899aabbccddeeff')
-  ).rejects.toThrow('No secure random generator');
-  crypto.webcrypto.getRandomValues = origGRV;
-  crypto.randomBytes = origRB;
-  global.crypto = nodeCrypto;
+
+  try {
+    const CW = require('../src');
+    await expect(
+      CW.AES.encrypt('x', '00112233445566778899aabbccddeeff')
+    ).rejects.toThrow('No secure random generator');
+  } finally {
+    crypto.webcrypto.getRandomValues = origGRV;
+    crypto.randomBytes = origRB;
+  }
 });
 
 test('works with ESM import and UMD global path', async () => {
@@ -64,15 +90,15 @@ test('works with ESM import and UMD global path', async () => {
   expect(cwReq.AES).toBeDefined();
 
   const { execFileSync } = require('child_process');
-  const out = execFileSync(process.execPath, ['-e', "import('./src/index.js').then(()=>console.log('ok'))"], { cwd: __dirname + '/..' });
-  expect(out.toString().trim()).toBe('ok');
+  const out = execFileSync(process.execPath, ['-e', "import('./src/index.js').then((mod)=>console.log(typeof mod.default.AES.encrypt))"], { cwd: __dirname + '/..' });
+  expect(out.toString().trim()).toBe('function');
 
   const fs = require('fs');
   const vm = require('vm');
   const code = fs.readFileSync(require.resolve('../src/index.js'), 'utf8');
   const ctx = { self: { crypto: { subtle: {} } }, Buffer, TextEncoder, TextDecoder };
   vm.runInNewContext(code, ctx);
-  expect(ctx.self.CryptoWeb).toBeDefined();
+  expect(ctx.self.CryptoWeb.AES.encrypt).toBeTypeOf('function');
 });
 
 test('throws on load when crypto.subtle missing', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -133,7 +133,7 @@
     const buf = new Uint8Array(withPadding);
     buf.set(bytes);
     buf[len] = 0x80;
-    for (let i = 0; i < 8; i++) buf[withPadding - 8 + i] = (bitLen >>> (8 * i)) & 0xff;
+    for (let i = 0; i < 8; i++) buf[withPadding - 8 + i] = Math.floor(bitLen / (2 ** (8 * i))) & 0xff;
     let a0 = 0x67452301, b0 = 0xefcdab89, c0 = 0x98badcfe, d0 = 0x10325476;
     const view = new DataView(buf.buffer);
     for (let i = 0; i < withPadding; i += 64) {


### PR DESCRIPTION
### Motivation
- Improve reliability and specification fidelity of environment-fallback tests by making them deterministic and ensuring proper cleanup of global state and mocks.
- Replace weak assertions that validated implementation details with exact, specification-based expectations (MD5 vector) to catch subtle correctness bugs.
- Fix an MD5 padding/bit-length encoding bug exposed by the stricter test.

### Description
- Hardened `__tests__/env_fallbacks.test.js` by adding `afterEach` cleanup, using `try/finally` to restore globals, and making fallback assertions deterministic (mocked `randomBytes` returning a fixed 16-byte IV and asserting the IV appears in the ciphertext).
- Replaced the MD5 fallback test length check with an exact test vector `MD5("abc") === '900150983cd24fb0d6963f7d28e17f72'` to verify correctness.
- Strengthened the ESM/UMD load test to assert the exported `AES.encrypt` is a function when importing as ESM.
- Fixed the JavaScript MD5 implementation bit-length encoding in `src/index.js` so the stricter MD5 test passes (replaced a right-shift encoding with an integer-division based byte extraction for the 64-bit length field).

### Testing
- Ran the full test suite with `npm test`; all tests passed: `7 test files`, `112 tests` all passing, and coverage report generated (Statements 96.27%, Lines 97.8%).
- Verified there are no `skip`/`only`/`todo` test markers with a repository-wide grep.
- All modified tests run and succeeded under Vitest after the fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31d2b2cc548320b09188b6eed9cfa6)